### PR TITLE
Fix broken pipe error when connections are closed early by the client.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix broken pipe error when connections are closed early by the client.
+  [jone]
 
 
 1.0.1 (2014-03-21)

--- a/ftw/maintenanceserver/server.py
+++ b/ftw/maintenanceserver/server.py
@@ -3,6 +3,7 @@ import SocketServer
 import os
 import posixpath
 import re
+import socket
 import urllib
 
 
@@ -17,6 +18,23 @@ def remove_virtual_host_monster_config(path):
 
 
 class HTTPRequestHandler(SimpleHTTPRequestHandler):
+
+    def __init__(self, request, client_address, server):
+        self.request = request
+        self.client_address = client_address
+        self.server = server
+        self.setup()
+
+        # Do not finish() when we have a broken pipe.
+        try:
+            self.handle()
+        except socket.error:
+            pass  # broken pipe
+        except:
+            self.finish()
+            raise
+        else:
+            self.finish()
 
     do_POST = SimpleHTTPRequestHandler.do_GET
 


### PR DESCRIPTION
When configuring the maintenanceserver with haproxy, haproxy makes perodically an OPTIONS request for checking if the server still response.
This OPTIONS request is closed as soon as the first bytes arrive.
This results in exceptions such as:

```
  File "/usr/local/python/2.7.5-i386/lib/python2.7/socket.py", line 303, in flush
    self._sock.sendall(view[write_offset:write_offset+buffer_size])
error: [Errno 32] Broken pipe
```

This happens when we try to write to a closed connection.

The default request handler always tries to cleanup (`finish()`) after each request, even when exceptions happen during the request. `finish()` tries to write the remaining data to the stream and close it.

This behavior is usually correct, but when there is a broken pipe calling `finish()` will result in another socket error (broken pip) since it tries to write to the closed socket again.

This changes the behavior so that the request is not finished when we have a socket error (broken pipe).
This eliminates the disturbing exceptions from the log.
