### PR TITLE
Avoid caching maintenance server responses.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid caching maintenance server responses. [jone]
 
 
 1.1.0 (2016-03-12)

--- a/ftw/maintenanceserver/server.py
+++ b/ftw/maintenanceserver/server.py
@@ -39,9 +39,19 @@ class HTTPRequestHandler(SimpleHTTPRequestHandler):
     do_POST = SimpleHTTPRequestHandler.do_GET
 
     def do_OPTIONS(self):
-        self.send_response(200)
+        self.send_response(200, method='OPTIONS')
         self.send_header('Allow', 'GET,HEAD,POST,OPTIONS')
+        self.send_header('Cache-Control', 'no-cache')
         self.end_headers()
+
+    def send_response(self, code, message=None, method=None):
+        # Always send "503 Service Unavailable" instead of "200 OK" so that
+        # caching proxies do not cache maintenance server responses.
+        if code == 200 and method != 'OPTIONS':
+            code = 503
+            message = None
+
+        return SimpleHTTPRequestHandler.send_response(self, code, message)
 
     def translate_path(self, path):
         path = remove_virtual_host_monster_config(path)


### PR DESCRIPTION
Respond to GET, POST, and HEAD requests with 503 Service Unavailable in order to avoid having the response cached in varnish or other cache proxies.
OPTIONS is still responded with 200 OK, but with Cache-Control=no-cache, because sending a 5xx-response for a OPTIONS-request will make HaProxy to shut down the backend because it might be broken.