### PR TITLE
Fix tests to be compatible with most recent ftw.testbrowser

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix tests to be compatible with most recent ftw.testbrowser. [lgraf]
 
 
 1.1.1 (2017-02-03)

--- a/ftw/maintenanceserver/testing.py
+++ b/ftw/maintenanceserver/testing.py
@@ -1,4 +1,5 @@
 from ftw.maintenanceserver.server import HTTPServer
+from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
 from plone.testing import Layer
 from threading import Thread
 import os
@@ -8,7 +9,10 @@ DOCUMENT_ROOT = os.path.join(os.path.dirname(__file__), 'tests', 'htdocs')
 ADDRESS = 'localhost'
 PORT = int(os.environ.get('ZSERVER_PORT', 55001))
 
+
 class ServerLayer(Layer):
+
+    defaultBases = (REQUESTS_BROWSER_FIXTURE, )
 
     def setUp(self):
         self.httpd = HTTPServer(DOCUMENT_ROOT, ADDRESS, PORT)

--- a/ftw/maintenanceserver/tests/test_server.py
+++ b/ftw/maintenanceserver/tests/test_server.py
@@ -28,6 +28,11 @@ class TestServer(TestCase):
         url = os.path.join(self.layer['URL'], path)
         browser.open(url, method=method)
 
+    def setUp(self):
+        # We actually *expect* the maintenance server to produce
+        # "HTTP Errors", such as "503 Service Unavailable"
+        browser.raise_http_errors = False
+
     @browsing
     @catch_stderr
     def test_server_serves_index_html(self, browser):

--- a/ftw/maintenanceserver/tests/test_server.py
+++ b/ftw/maintenanceserver/tests/test_server.py
@@ -1,7 +1,7 @@
-from StringIO import StringIO
 from ftw.maintenanceserver.testing import SERVER_LAYER
 from ftw.testbrowser import browser
 from ftw.testbrowser import browsing
+from StringIO import StringIO
 from unittest2 import TestCase
 import os.path
 import sys
@@ -26,7 +26,7 @@ class TestServer(TestCase):
 
     def open(self, path, method='GET'):
         url = os.path.join(self.layer['URL'], path)
-        browser.webdav(method, url)
+        browser.open(url, method=method)
 
     @browsing
     @catch_stderr


### PR DESCRIPTION
Fixes tests to be compatible with most recent version of `ftw.testbrowser`:
- Use `REQUESTS_BROWSER_FIXTURE` to [explicitly select](http://ftwtestbrowser.readthedocs.io/en/stable/userdoc.html?highlight=webdav#choosing-the-default-driver) the requests driver
- Use `browser.open(method=...)` instead of abusing `browser.webdav()`
- Don't raise HTTP errors, we expect `ftw.maintenanceserver` to produce "HTTP Errors" such as `503 Service Unavailable`