### PR TITLE
Respond with 200 OK to resources request.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+- Respond with 200 OK to resources request. [njohner]
 - Fix tests to be compatible with most recent ftw.testbrowser. [lgraf]
 
 

--- a/ftw/maintenanceserver/server.py
+++ b/ftw/maintenanceserver/server.py
@@ -45,9 +45,10 @@ class HTTPRequestHandler(SimpleHTTPRequestHandler):
         self.end_headers()
 
     def send_response(self, code, message=None, method=None):
-        # Always send "503 Service Unavailable" instead of "200 OK" so that
-        # caching proxies do not cache maintenance server responses.
-        if code == 200 and method != 'OPTIONS':
+        # Send "503 Service Unavailable" instead of "200 OK" so that
+        # caching proxies do not cache maintenance server responses,
+        # except to resources request.
+        if code == 200 and method != 'OPTIONS' and not self.is_resource:
             code = 503
             message = None
 
@@ -67,12 +68,15 @@ class HTTPRequestHandler(SimpleHTTPRequestHandler):
         filepath = os.path.abspath(os.path.join(document_root, *words))
 
         if not os.path.isfile(filepath):
+            self.is_resource = False
             return index
 
         elif not filepath.startswith(document_root):
+            self.is_resource = False
             return index
 
         else:
+            self.is_resource = True
             return filepath
 
 

--- a/ftw/maintenanceserver/tests/test_server.py
+++ b/ftw/maintenanceserver/tests/test_server.py
@@ -115,3 +115,9 @@ class TestServer(TestCase):
         self.open('VirtualHostBase/http/localhost:8080/mountpoint/'
                   'Plone/VirtualHostRoot/_vh_the/_vh_site/images/logo.png')
         self.assertEquals('TheLogo', browser.contents.strip())
+
+    @browsing
+    @catch_stderr
+    def test_resources_get_200(self, browser):
+        self.open('images/logo.png')
+        self.assertEquals(200, browser.status_code)


### PR DESCRIPTION
We now respond with 200 OK when we send a local resource back.
Also added a test to check that we indeed respond 200 for resources.